### PR TITLE
Helper sign_in_with_2fa

### DIFF
--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -39,8 +39,13 @@ module TwoFactorAuthentication
   REMEMBER_TFA_COOKIE_NAME = "remember_tfa"
 
   autoload :Schema, 'two_factor_authentication/schema'
+
   module Controllers
     autoload :Helpers, 'two_factor_authentication/controllers/helpers'
+  end
+
+  module Test
+    autoload :IntegrationHelpers, 'two_factor_authentication/test/integration_helpers'
   end
 end
 

--- a/lib/two_factor_authentication/test/integration_helpers.rb
+++ b/lib/two_factor_authentication/test/integration_helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module TwoFactorAuthentication
+  # TwoFactorAuthentication::Test::IntegrationHelpers is a helper module for facilitating
+  # two-factor authentication on Rails integration tests to bypass the required steps for
+  # entering OTP codes.
+  #
+  # Examples
+  #
+  #  class PostsTest < ActionDispatch::IntegrationTest
+  #    include Devise::Test::IntegrationHelpers
+  #    include TwoFactorAuthentication::Test::IntegrationHelpers
+  #
+  #    test 'authenticated users can see posts' do
+  #      sign_in_with_2fa users(:bob)
+  #
+  #      get '/posts'
+  #      assert_response :success
+  #    end
+  #  end
+  module Test
+    module IntegrationHelpers
+
+      # Signs in a specific resource without needing two-factor authentication,
+      # mimicking a successful sign in operation through +Devise::SessionsController#create+.
+      #
+      # * +resource+ - The resource that should be authenticated
+      # * +scope+    - An optional +Symbol+ with the scope where the resource
+      #                should be signed in with.
+      def sign_in_with_2fa(resource, scope: nil)
+        cookie_name = TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME
+        dummy_cookies = ActionDispatch::Request.new(Rails.application.env_config.deep_dup).cookie_jar
+        dummy_cookies.signed[cookie_name] = "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}"
+        cookies[cookie_name] = dummy_cookies[cookie_name]
+        sign_in(resource, scope: scope)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Ajout d'un helper pour simuler la présence du cookie `REMEMBER_TFA_COOKIE_NAME` afin de pouvoir se connecter depuis une méthode de test sans avoir besoin d'un code MFA